### PR TITLE
add flag to remove code highlights from slide export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/markdown-to-pdf/markdown-to-pdf.sh
+++ b/markdown-to-pdf/markdown-to-pdf.sh
@@ -57,9 +57,7 @@ for FILE in "$@" ; do
     if [ $IGNORE_HIGHLIGHTS = 1 ]
     then
       cp $md_file $backup_file;
-      convert_file="${FILE%.*}.convert.md"
-      sed -E 's/\[.code-highlight.+]//g' $md_file > $convert_file
-      mv $convert_file $md_file
+      sed -i '' -E  's/\[.code-highlight.+]//g' $md_file
     fi
 
     osascript <<EOF


### PR DESCRIPTION
This adds an option `c` to ignore code highlights from the slide export process.  In a presentation I am doing, I have a bunch of slides that start with only one or two lines of code highlighted, so when the slides are exported, you only see whatever the first state is, which I don't like in the PDF.

In order to keep theming consistent without having to specify the them in the markdown file the strategy is to create a backup copy of the presentation, then modify the markdown file, run the export and then restore the original file back so that all the code highlights, etc will be back in.  

To run the command in this example: `./markdown-to-pdf.sh -cf /path/to/file.md`  

There is perhaps a better way to do this in a future update to DeckSet, but for now this solves the immediate problem. 